### PR TITLE
Talentbot should only care about message events

### DIFF
--- a/talentbot.py
+++ b/talentbot.py
@@ -111,8 +111,8 @@ class TalentBot:
             self.processEvent(SlackEvent(event))
 
     def processEvent(self, event):
-        if not event.hasUser():
-            logging.debug("Event without user\n- %s" % event)
+        if not event.isMessage():
+            logging.debug("Non-message event\n- %s" % event)
             return
     
         if event.isTalentBot():


### PR DESCRIPTION
Efter senaste mergen så började jag se felloggar på följande event från Slack:

 {'channel': 'D0CJSFSD1',
 'type': 'user_typing',
 'user': 'U025UNSF9'}

Löser det genom att talentbot ignorerar event som inte har type=message.
